### PR TITLE
Add Freenode Web IRC badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IPFS - The Permanent Web
 
+[![ipfs](http://img.shields.io/irc/%23ipfs.png)](https://webchat.freenode.net/?channels=ipfs)
+
 IPFS is a distributed file system that seeks to connect all computing devices with the same system of files. In some ways, this is similar to the original aims of the Web, but IPFS is actually more similar to a single bittorrent swarm exchanging git objects.
 
 IPFS could become a new major subsystem of the internet. If built right, it could complement or replace HTTP. It could complement or replace even more. It sounds crazy. It _is_ crazy.


### PR DESCRIPTION
This adds a badge that links to Freenode's web irc portal and auto-populate `#ipfs` as the default channel to join.

This is a response to the feedback left in #55.